### PR TITLE
Add track selection support and selection-aware playback

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ export default function AudioForge() {
     startRecording,
     stopRecording,
     updateTrack,
+    setTrackSelection,
     exportProject,
     importAudio,
     trimTrack,
@@ -84,6 +85,7 @@ export default function AudioForge() {
             onTrackPlayPause={toggleTrackPlayback}
             onTrackStop={stopTrackPlayback}
             onTrackRecord={toggleTrackRecording}
+            onSelectionChange={setTrackSelection}
           />
         </div>
         <EffectsPanel track={selectedTrack} onTrackUpdate={updateTrack} />

--- a/src/components/audio-forge/track-view.tsx
+++ b/src/components/audio-forge/track-view.tsx
@@ -18,6 +18,7 @@ interface TrackViewProps {
   onTrackPlayPause: (id: string) => void;
   onTrackStop: (id: string) => void;
   onTrackRecord: (id: string) => void;
+  onSelectionChange: (id: string, selection: { start: number; end: number } | null) => void;
 }
 
 export function TrackView({
@@ -31,6 +32,7 @@ export function TrackView({
   onTrackPlayPause,
   onTrackStop,
   onTrackRecord,
+  onSelectionChange,
 }: TrackViewProps) {
   return (
     <div className="flex-1 flex flex-col bg-background p-4 gap-4 overflow-hidden">
@@ -55,6 +57,7 @@ export function TrackView({
                 onPlayPause={onTrackPlayPause}
                 onStop={onTrackStop}
                 onRecord={onTrackRecord}
+                onSelectionChange={onSelectionChange}
               />
             ))
           ) : (

--- a/src/components/audio-forge/track.tsx
+++ b/src/components/audio-forge/track.tsx
@@ -1,7 +1,6 @@
 
 "use client";
 
-import { useState } from 'react';
 import type { Track as TrackType } from '@/hooks/use-audio-engine';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -23,6 +22,7 @@ interface TrackProps {
   onPlayPause: (id: string) => void;
   onStop: (id: string) => void;
   onRecord: (id: string) => void;
+  onSelectionChange: (id: string, selection: { start: number; end: number } | null) => void;
 }
 
 export function Track({
@@ -35,8 +35,12 @@ export function Track({
   onPlayPause,
   onStop,
   onRecord,
+  onSelectionChange,
 }: TrackProps) {
-  const [selection, setSelection] = useState<{ start: number; end: number } | null>(null);
+  const selection =
+    track.selectionStart !== null && track.selectionEnd !== null
+      ? { start: track.selectionStart, end: track.selectionEnd }
+      : null;
 
   const handleVolumeChange = (value: number[]) => {
     onUpdate(track.id, { volume: value[0] });
@@ -62,7 +66,7 @@ export function Track({
     e.stopPropagation();
     if (selection && track) {
       onTrim(track.id, selection.start, selection.end);
-      setSelection(null);
+      onSelectionChange(track.id, null);
     }
   };
 
@@ -201,7 +205,7 @@ export function Track({
               size="sm"
               variant="outline"
               className="w-full"
-              disabled={!selection || (selection.start === selection.end)}
+              disabled={!selection}
               onClick={handleTrim}
             >
               <Scissors />
@@ -211,9 +215,11 @@ export function Track({
         </div>
         <div className="flex-1">
           <Waveform
+            trackId={track.id}
             url={track.url}
             duration={track.duration}
-            onSelectionChange={setSelection}
+            selection={selection}
+            onSelectionChange={onSelectionChange}
           />
         </div>
       </CardContent>

--- a/src/components/audio-forge/waveform.tsx
+++ b/src/components/audio-forge/waveform.tsx
@@ -5,23 +5,29 @@ import React, { useRef, useEffect, useCallback, useState, memo } from 'react';
 import * as Tone from 'tone';
 
 interface WaveformProps {
+  trackId: string;
   url?: string;
-  onSelectionChange?: (selection: { start: number; end: number } | null) => void;
+  selection: { start: number; end: number } | null;
+  onSelectionChange?: (trackId: string, selection: { start: number; end: number } | null) => void;
   duration: number | null;
 }
 
-const WaveformComponent: React.FC<WaveformProps> = ({ url, onSelectionChange, duration }) => {
+const WaveformComponent: React.FC<WaveformProps> = ({ trackId, url, onSelectionChange, duration, selection: selectionProp }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [waveform, setWaveform] = useState<Float32Array | null>(null);
-  const [selection, setSelection] = useState<{ start: number; end: number } | null>(null);
+  const [selection, setSelection] = useState<{ start: number; end: number } | null>(selectionProp);
   const [isDragging, setIsDragging] = useState(false);
   const dragStartRef = useRef(0);
+
+  useEffect(() => {
+    setSelection(selectionProp);
+  }, [selectionProp]);
 
   useEffect(() => {
     if (!url) {
       setWaveform(null);
       setSelection(null);
-      onSelectionChange?.(null);
+      onSelectionChange?.(trackId, null);
       return;
     }
 
@@ -42,12 +48,12 @@ const WaveformComponent: React.FC<WaveformProps> = ({ url, onSelectionChange, du
 
     // Reset selection when URL changes
     setSelection(null);
-    onSelectionChange?.(null);
+    onSelectionChange?.(trackId, null);
 
     return () => {
       mounted = false;
     };
-  }, [url, onSelectionChange]);
+  }, [url, onSelectionChange, trackId]);
   
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -139,10 +145,10 @@ const WaveformComponent: React.FC<WaveformProps> = ({ url, onSelectionChange, du
     if (!isDragging) return;
     setIsDragging(false);
     if (selection && selection.start !== selection.end) {
-      onSelectionChange?.(selection);
+      onSelectionChange?.(trackId, selection);
     } else {
       setSelection(null);
-      onSelectionChange?.(null);
+      onSelectionChange?.(trackId, null);
     }
   };
   


### PR DESCRIPTION
## Summary
- add per-track selection fields to the audio engine and expose a setter for UI updates
- enhance waveform and track components to surface selection changes and sync highlights
- start, stop, and rewind individual players from the stored selection range when defined

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d1defd61788320966336a46cfa023d